### PR TITLE
Punishment XP and item loss

### DIFF
--- a/gamemodes/modules/functions.pwn
+++ b/gamemodes/modules/functions.pwn
@@ -481,3 +481,51 @@ CreateScavArea(Float:scavPosX, Float:scavPosY, Float:scavPosZ, scavIntWorld, sca
         .testlos = 1, .worldid = scavVirWorld, .interiorid = scavIntWorld);
     return 1;
 }
+
+ReducePlayerInventoryAndExp(playerid)
+{
+    // EXP reduction (both human and zombie)
+    player[playerid][exp] = floatround(player[playerid][exp] * 0.8, floatround_floor);
+
+    // Zombie check
+    if (player[playerid][iszombie] == 1)
+    {
+        new zombieMessages[][] = {
+            "You jolt back to unlife. Hunger gnaws at what's left of you.",
+            "Your corpse stirs. There's no pain. Only hunger.",
+            "The rot deepens. Your limbs twitch with borrowed strength.",
+            "Your vision returns in a haze of red. Something inside you screams for flesh.",
+            "Death spits you back out. Again."
+        };
+
+        new zmsg = random(sizeof(zombieMessages));
+        SendClientMessage(playerid, COLOR_RP_PURPLE, zombieMessages[zmsg]);
+        return;
+    }
+
+    // Human: reduce inventory
+    new keysToReduce[] = {
+        1, 2, 3, 4, 7, 9,
+        10, 11, 12, 13, 14,
+        18, 19, 20, 21, 22,
+        26, 27
+    };
+
+    for (new i = 0; i < sizeof(keysToReduce); i++)
+    {
+        new slot = keysToReduce[i];
+        playerInventory[playerid][slot] = floatround(playerInventory[playerid][slot] * 0.8, floatround_floor);
+    }
+
+    // Human messages
+    new humanMessages[][] = {
+        "You regain consciousness. You feel weakened and your backpack feels lighter.",
+        "You wake up gasping, everything aches — something's missing.",
+        "You stumble back to your feet, disoriented. Some of your supplies are gone.",
+        "Your vision swims. You're alive, but not unscathed.",
+        "Pain brings you back. Cold sweat. Lighter load."
+    };
+
+    new hmsg = random(sizeof(humanMessages));
+    SendClientMessage(playerid, COLOR_RP_PURPLE, humanMessages[hmsg]);
+}

--- a/gamemodes/zorp.pwn
+++ b/gamemodes/zorp.pwn
@@ -271,12 +271,34 @@ public OnPlayerDeath(playerid, killerid, reason)
 	KillTimer(player[playerid][fuelTimer]);
 	KillTimer(player[playerid][fillVehicleTimer]);
 	HideHudForPlayer(playerid);
-	/*
-	*testing xp Loss
-	*/
-	player[playerid][exp] = math_floor(player[playerid][exp]*0.8);
-    UpdateHudElementForPlayer(playerid, HUD_INFO);
+	
+	/*Reduce the xp and inv items by 20% with the exception for weapons and key items. */
 
+	new keysToReduce[] = {
+		-1, // -1 represents "exp"
+		1, 2, 3, 4, 7, 9,
+		10, 11, 12, 13, 14,
+		18, 19, 20, 21, 22,
+		26, 27
+	};
+
+	for (new i = 0; i < sizeof(keysToReduce); i++) {
+		if (keysToReduce[i] == -1) {
+			// Reduce EXP, make sure it doesn't go below 0
+			player[playerid][exp] = floatround(player[playerid][exp] * 0.8, floatround_floor);
+			if (player[playerid][exp] < 0) player[playerid][exp] = 0;
+		} else {
+			// Reduce item in inventory, make sure it doesn't go below 0
+			playerInventory[playerid][keysToReduce[i]] =
+				floatround(playerInventory[playerid][keysToReduce[i]] * 0.8, floatround_floor);
+
+			if (playerInventory[playerid][keysToReduce[i]] < 0)
+				playerInventory[playerid][keysToReduce[i]] = 0;
+		}
+	}
+
+
+	UpdateHudElementForPlayer(playerid, HUD_INFO);
 	/*
 	* Set the player to spectate mode and set the timer to respawn
 	*/

--- a/gamemodes/zorp.pwn
+++ b/gamemodes/zorp.pwn
@@ -274,8 +274,8 @@ public OnPlayerDeath(playerid, killerid, reason)
 	/*
 	*testing xp Loss
 	*/
-	player[playerid][exp] *= 0.8;
-                UpdateHudElementForPlayer(playerid, HUD_INFO);
+	player[playerid][exp] = math_floor(player[playerid][exp]*0.8);
+    UpdateHudElementForPlayer(playerid, HUD_INFO);
 
 	/*
 	* Set the player to spectate mode and set the timer to respawn

--- a/gamemodes/zorp.pwn
+++ b/gamemodes/zorp.pwn
@@ -272,31 +272,8 @@ public OnPlayerDeath(playerid, killerid, reason)
 	KillTimer(player[playerid][fillVehicleTimer]);
 	HideHudForPlayer(playerid);
 	
-	/*Reduce the xp and inv items by 20% with the exception for weapons and key items. */
-
-	new keysToReduce[] = {
-		-1, // -1 represents "exp"
-		1, 2, 3, 4, 7, 9,
-		10, 11, 12, 13, 14,
-		18, 19, 20, 21, 22,
-		26, 27
-	};
-
-	for (new i = 0; i < sizeof(keysToReduce); i++) {
-		if (keysToReduce[i] == -1) {
-			// Reduce EXP, make sure it doesn't go below 0
-			player[playerid][exp] = floatround(player[playerid][exp] * 0.8, floatround_floor);
-			if (player[playerid][exp] < 0) player[playerid][exp] = 0;
-		} else {
-			// Reduce item in inventory, make sure it doesn't go below 0
-			playerInventory[playerid][keysToReduce[i]] =
-				floatround(playerInventory[playerid][keysToReduce[i]] * 0.8, floatround_floor);
-
-			if (playerInventory[playerid][keysToReduce[i]] < 0)
-				playerInventory[playerid][keysToReduce[i]] = 0;
-		}
-	}
-
+	/*Reduce the xp and inv items by 20% with the exception for weapons and key items. Send on-death message*/
+	ReducePlayerInventoryAndExp(playerid);
 
 	UpdateHudElementForPlayer(playerid, HUD_INFO);
 	/*

--- a/gamemodes/zorp.pwn
+++ b/gamemodes/zorp.pwn
@@ -271,6 +271,11 @@ public OnPlayerDeath(playerid, killerid, reason)
 	KillTimer(player[playerid][fuelTimer]);
 	KillTimer(player[playerid][fillVehicleTimer]);
 	HideHudForPlayer(playerid);
+	/*
+	*testing xp Loss
+	*/
+	player[playerid][exp] *= 0.8;
+                UpdateHudElementForPlayer(playerid, HUD_INFO);
 
 	/*
 	* Set the player to spectate mode and set the timer to respawn


### PR DESCRIPTION
Death reduces earned XP and all food, drink, medicinal and ammo items by 20%.